### PR TITLE
Added index.html handler to support connection from MeshSense App

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,3 +92,19 @@ async def fromradio(all: TFStr="false"):
     elif len(bufs) > 0:
         content = bufs.pop(0)
     return Response(content=content, media_type="application/x-protobuf")
+
+@app.get("/index.html")
+async def index():
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Meshtastic HTTP Proxy</title>
+    </head>
+    <body>
+        <h1>Welcome to the Meshtastic HTTP Proxy</h1>
+        <p>More information is available here: <a href="https://github.com/ianmcorvidae/meshtastic-http-proxy">https://github.com/ianmcorvidae/meshtastic-http-proxy</a></p>
+    </body>
+    </html>
+    """
+    return HTMLResponse(content=html_content, status_code=200)


### PR DESCRIPTION
Added index.html handler to support connection from MeshSense App.
MeshSense fails if it doesn't get an OK response for /index.html.

It doesn't care what the response is, so I just made it a simple link to the github project.

Thanks for making this. I found this project through your response here:
https://github.com/orgs/meshtastic/discussions/68

I wanted to use / monitor my RAK wireless POE meshtastic module via the meshsense app.

More information about meshsense here:
https://affirmatech.com/meshsense

(Change tested with MeshSense v 1.1.0-beta.8 and a RAK wireless 4631 w/ POE module running: firmware-rak4631_eth_gw-2.6.11.60ec05e.)